### PR TITLE
Add support for the default-testbed metadata

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -389,6 +389,8 @@ def test_containers_autorestart(
               critical process to verify the container will be stopped and restarted
     """
     dut_name, feature = decode_dut_port_name(enum_dut_feature_container)
+    if dut_name == "default-dut":
+        dut_name = enum_rand_one_per_hwsku_frontend_hostname
     pytest_require(
         dut_name == enum_rand_one_per_hwsku_frontend_hostname and feature != "unknown",
         "Skip test on dut host {} (chosen {}) feature {}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def get_specified_duts(request):
     if len(testbed_duts) != specified_duts:
         duts = specified_duts
         logger.debug("Different DUTs specified than in testbed file, using {}"
-                    .format(str(duts)))
+                    .format(str(specified_duts)))
 
     return duts
 
@@ -923,7 +923,10 @@ def generate_dut_feature_container_list(request):
 
     folder = "metadata"
     filepath = os.path.join(folder, tbname + ".json")
-
+    if not os.path.exists(filepath):
+        tbname = "default-testbed"
+        filepath = os.path.join(folder, tbname + ".json")
+    
     try:
         with open(filepath, "r") as yf:
             metadata = json.load(yf)


### PR DESCRIPTION
To define one json file for every testbed is time-consuming and hard to maintain, for test_container_autorestart, testbeds can share information defined in the default-testbed.json

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add support for the default-testbed metadata
Fixes # (issue) To define one json file for every testbed is time-consuming and hard to maintain, for test_container_autorestart, testbeds can share information defined in the default-testbed.json

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add support for the default-testbed.json metadata which can save the information used for test_container_autorestart
#### How did you do it?
In the script, when parse the data for the test_container_autorestart, if the {dut_name}-testbed.json is not found, then, use the default-testbed.json
#### How did you verify/test it?
Create a default-testbed.json, and run the test_container_autorestart:
py.test autorestart/test_container_autorestart.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern r-tigon-04 --module-path                ../ansible/library/ --testbed r-tigon-04-t0 --testbed_file ../ansible/testbed.csv                --allow_recover                --junit-xml junit_5002672_0.7.1.1.3.1.1.3.1.1.1.xml --assert plain --log-cli-level info --show-capture=no -ra --showlocals --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id r-tigon-04-autorestart-tests-test-autorestart-py --disable_loganalyzer --skip_sanity

