### PR TITLE
[Issue] Make sure the pcap file is not exist for every sub test case in test_syslog

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -50,6 +50,8 @@ def test_syslog(duthosts, enum_rand_one_per_hwsku_frontend_hostname, dummy_syslo
         logger.debug("Added new rsyslog server IP {}".format(dummy_syslog_server_ip_b))
 
     logger.info("Start tcpdump")
+    # Make sure that the DUT_PCAP_FILEPATH is not exist
+    duthost.shell("sudo rm -f {}".format(DUT_PCAP_FILEPATH))
     # Scapy doesn't support LINUX_SLL2 (Linux cooked v2), and tcpdump on Bullseye
     # defaults to writing in that format when listening on any interface. Therefore,
     # have it use LINUX_SLL (Linux cooked) instead.


### PR DESCRIPTION
There are sub test cases in test_syslog, need to make sure the pcap file is not exist before save the pcap file.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: There are sub test cases in test_syslog, need to make sure the pcap file is not exist before save the pcap file.
Fixes # (issue) 1st sub test case will save pcap file, and when save the pacp file in the 2nd sub test case, it will include the config in the 1st sub test case, and for bullseye, it tcpdump command will get failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make sure the pcap file is not exist for every sub test case in test_syslog.
#### How did you do it?
remove the pcap file before saving the pcap file in the sub test case
#### How did you verify/test it?
run the test_syslog test case:
 py.test syslog/test_syslog.py --inventory="../ansible/inventory,../ansible/veos" --host-pattern r-leopard-01 --module-path                ../ansible/library/ --testbed r-leopard-01-t0 --testbed_file ../ansible/testbed.csv                --allow_recover  --session_id 5279741 --mars_key_id 0.7.1.1.11.1.5.3.1.1.1                --junit-xml junit_5279741_0.7.1.1.11.1.5.3.1.1.1.xml --assert plain --log-cli-level debug --show-capture=no -ra --showlocals --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id=r-leopard-01-syslog-test-syslog-py 
#### Any platform specific information?
No