### PR TITLE
[auto_negotiation]Optimize the execution time for test_auto_negotiation.py

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -59,7 +59,8 @@ def loganalyzer(duthosts, request):
     yield analyzers
 
     # Skip LogAnalyzer if case is skipped
-    if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped:
+    if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped or \
+            "rep_setup" in request.node.__dict__ and request.node.rep_setup.skipped:
         return
     logging.info("Starting to analyse on all DUTs")
     parallel_run(analyze_logs, [analyzers, markers], {}, duthosts, timeout=120)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1182,7 +1182,7 @@ def pytest_generate_tests(metafunc):
     if "enum_dut_portname" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))
     if "enum_dut_portname_module_fixture" in metafunc.fixturenames:
-        metafunc.parametrize("enum_dut_portname_module_fixture", generate_port_lists(metafunc, "all_ports"), scope="module", indirect=True)
+        metafunc.parametrize("enum_dut_portname_module_fixture", generate_port_lists(metafunc, "admin_up_ports"), scope="module", indirect=True)
     if "enum_dut_portname_oper_up" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname_oper_up", generate_port_lists(metafunc, "oper_up_ports"))
     if "enum_dut_portname_admin_up" in metafunc.fixturenames:

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -275,7 +275,7 @@ def test_auto_negotiation_dut_advertises_each_speed(enum_dut_portname_module_fix
 
     # Advertise all supported speeds in fanout port
     success = fanout.set_speed(fanout_port, None)
-    pytest_require(success, 'Failed to advertise speed on fanout port {}, speed {}'.format(fanout_port, speed))
+    pytest_require(success, 'Failed to advertise speed on fanout port {}'.format(fanout_port))
 
     logger.info('Trying to get a common supported speed set among dut port, fanout port and cable')
     supported_speeds = get_supported_speeds_for_port(duthost, dut_port, fanout, fanout_port)


### PR DESCRIPTION
1. It should not take all the ports as the params for the test case, only ports are admin up is enough, the useless params will increase the run time, for one skip testcase, it take around 11-12 seconds.
2. If the test case is skipped in the fixture, then it will not skip analyzing logs, it take about 6s for 1 test case.
3. Fix issue in test_auto_negotiation_dut_advertises_each_speed, speed is not defined before using it.

For example, on  -2700-t0, there are 56 ports, but only 28 ports are up, then, (56-28) * 4 = 112 test cases will not generate, before the code change, these test case will always be skipped,so it means we save time for execute 112 skipped test cases. more admin down ports in the setup, more execution time will be saved.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Optimize the execution time for test_auto_negotiation.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. Reduce the params with not taking the admin down ports to the params.
2. when the test case is skipped in the setup setup, make sure the loganalyzer will not be executed.
#### How did you verify/test it?
Run the test case and compare the execution time.
take 2700-t0 as example, there are  56 ports, but only 28 admin up ports. The execution time for the test case is:
Before optimize : 5895.93 seconds
After optimize: 3482.95 seconds
After optimization, it saved 40 mins on this setup
and for some other setup which has more admin down ports, it will save more time.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
