### PR TITLE
[test_sfp.py:test_reset]Modify the logic for check if the cable can be reset or not

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -111,3 +111,6 @@ def check_not_implemented_warnings(duthosts, enum_rand_one_per_hwsku_hostname):
     loganalyzer.match_regex.extend(['WARNING pmon#platform_api_server.py: API.+not implemented'])
     loganalyzer.analyze(marker)
     
+
+def pytest_addoption(parser):
+    parser.addoption("--unresettable_xcvr_types", action="append", default=[], help="unsupported resettable xcvr types")

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -170,11 +170,10 @@ class TestSfpApi(PlatformApiTestBase):
                         return False
         return True
 
-    def is_xcvr_resettable(self, xcvr_info_dict):
+    def is_xcvr_resettable(self, request, xcvr_info_dict):
+        not_resettable_xcvr_type = request.config.getoption("--unresettable_xcvr_types")
         xcvr_type = xcvr_info_dict.get("type_abbrv_name")
-        if xcvr_type == "SFP":
-            return False
-        return True
+        return xcvr_type not in not_resettable_xcvr_type
 
     def is_xcvr_support_lpmode(self, xcvr_info_dict):
         """Returns True if transceiver is support low power mode, False if not supported"""
@@ -469,7 +468,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_reset(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_reset(self, request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Verify that the transceiver was actually reset
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -480,7 +479,7 @@ class TestSfpApi(PlatformApiTestBase):
                continue
 
             ret = sfp.reset(platform_api_conn, i)
-            if self.is_xcvr_resettable(info_dict):
+            if self.is_xcvr_resettable(request, info_dict):
                self.expect(ret is True, "Failed to reset transceiver {}".format(i))
             else:
                self.expect(ret is False, "Resetting transceiver {} succeeded but should have failed".format(i))


### PR DESCRIPTION
For some plaform, the SFP cable can not reset, and for some platform, SFP cable can be reset, and RJ45 can not reset
Add the option --unresettable_xcvr_types to let customer specify the type which type can not reset

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modify the logic for check if the cable can be reset or not
Fixes # (issue) Modify the logic for check if the cable can be reset or not

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Modify the logic for check if the cable can be reset or not
#### How did you do it?
Add option --unresettable_xcvr_types to let customer specify which types are not support to reset
#### How did you verify/test it?
Run the test_sfp.py::test_reset on with the SFP port, the test can pass
 py.test platform_tests/api/test_sfp.py::TestSfpApi::test_reset --unresettable_xcvr_types "SFP"
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
